### PR TITLE
add script to update additional exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,3 +402,58 @@ Interpretador:
 
 Linguagem de Máquina:
 
+
+## Exemplos Adicionados
+
+| Nome do Exemplo           | Link                               |
+|---------------------------|------------------------------------|
+| 041                       | [Acessar Código](./code-atividades/041.py) |
+| Calcarea                  | [Acessar Código](./code-atividades/calcArea.py) |
+| Ex001                     | [Acessar Código](./code-atividades/ex001.py) |
+| Ex002                     | [Acessar Código](./code-atividades/ex002.py) |
+| Ex003                     | [Acessar Código](./code-atividades/ex003.py) |
+| Ex004                     | [Acessar Código](./code-atividades/ex004.py) |
+| Ex005                     | [Acessar Código](./code-atividades/ex005.py) |
+| Ex006                     | [Acessar Código](./code-atividades/ex006.py) |
+| Ex007                     | [Acessar Código](./code-atividades/ex007.py) |
+| Ex008                     | [Acessar Código](./code-atividades/ex008.py) |
+| Ex009                     | [Acessar Código](./code-atividades/ex009.py) |
+| Ex010                     | [Acessar Código](./code-atividades/ex010.py) |
+| Ex011                     | [Acessar Código](./code-atividades/ex011.py) |
+| Ex012                     | [Acessar Código](./code-atividades/ex012.py) |
+| Ex013                     | [Acessar Código](./code-atividades/ex013.py) |
+| Ex014                     | [Acessar Código](./code-atividades/ex014.py) |
+| Ex015                     | [Acessar Código](./code-atividades/ex015.py) |
+| Ex016                     | [Acessar Código](./code-atividades/ex016.py) |
+| Ex017                     | [Acessar Código](./code-atividades/ex017.py) |
+| Ex018                     | [Acessar Código](./code-atividades/ex018.py) |
+| Ex019                     | [Acessar Código](./code-atividades/ex019.py) |
+| Ex039                     | [Acessar Código](./code-atividades/ex039.py) |
+| Ex040                     | [Acessar Código](./code-atividades/ex040.py) |
+| Ex042                     | [Acessar Código](./code-atividades/ex042.py) |
+| Ex043                     | [Acessar Código](./code-atividades/ex043.py) |
+| Ex044                     | [Acessar Código](./code-atividades/ex044.py) |
+| Ex045                     | [Acessar Código](./code-atividades/ex045.py) |
+| Ex20                      | [Acessar Código](./code-atividades/ex20.py) |
+| Ex21                      | [Acessar Código](./code-atividades/ex21.py) |
+| Ex22                      | [Acessar Código](./code-atividades/ex22.py) |
+| Ex23                      | [Acessar Código](./code-atividades/ex23.py) |
+| Ex24                      | [Acessar Código](./code-atividades/ex24.py) |
+| Ex25                      | [Acessar Código](./code-atividades/ex25.py) |
+| Ex26                      | [Acessar Código](./code-atividades/ex26.py) |
+| Ex27                      | [Acessar Código](./code-atividades/ex27.py) |
+| Ex28                      | [Acessar Código](./code-atividades/ex28.py) |
+| Ex29                      | [Acessar Código](./code-atividades/ex29.py) |
+| Ex30                      | [Acessar Código](./code-atividades/ex30.py) |
+| Ex31                      | [Acessar Código](./code-atividades/ex31.py) |
+| Ex32                      | [Acessar Código](./code-atividades/ex32.py) |
+| Ex33                      | [Acessar Código](./code-atividades/ex33.py) |
+| Ex34                      | [Acessar Código](./code-atividades/ex34.py) |
+| Ex35                      | [Acessar Código](./code-atividades/ex35.py) |
+| Ex36                      | [Acessar Código](./code-atividades/ex36.py) |
+| Ex37                      | [Acessar Código](./code-atividades/ex37.py) |
+| Ex38                      | [Acessar Código](./code-atividades/ex38.py) |
+| Ex41                      | [Acessar Código](./code-atividades/ex41.py) |
+| Ex46                      | [Acessar Código](./code-atividades/ex46.py) |
+| Ex48                      | [Acessar Código](./code-atividades/ex48.py) |
+| Main                      | [Acessar Código](./code-atividades/main.py) |

--- a/atualizar_tabela.py
+++ b/atualizar_tabela.py
@@ -1,0 +1,48 @@
+import os
+
+# Caminho para a pasta de exemplos e para o README.md
+EXEMPLOS_DIR = "code-atividades"
+README_FILE = "README.md"
+
+def atualizar_tabela():
+    # Começamos com o cabeçalho da tabela
+    tabela = "| Nome do Exemplo           | Link                               |\n"
+    tabela += "|---------------------------|------------------------------------|\n"
+    
+    # Lista todos os arquivos Python na pasta exemplos
+    for filename in os.listdir(EXEMPLOS_DIR):
+        if filename.endswith(".py"):  # Só vamos pegar os arquivos .py
+            # Formatar o nome do exemplo (remover .py e substituir _ por espaço)
+            nome = filename.replace('_', ' ').replace('.py', '').title()
+            
+            # Cria o link para o código
+            link = f"./{EXEMPLOS_DIR}/{filename}"
+            tabela += f"| {nome:<25} | [Acessar Código]({link}) |\n"
+    
+    # Lê o conteúdo atual do README.md
+    with open(README_FILE, "r", encoding='utf-8') as readme:
+        conteudo = readme.readlines()
+    
+    # Procurar a seção onde a tabela deve começar
+    inicio_tabela = -1
+    for i, linha in enumerate(conteudo):
+        if linha.strip() == "## Exemplos Adicionados":
+            inicio_tabela = i + 2  # Linha onde a tabela começa
+            break
+    
+    # Atualiza a tabela no README
+    if inicio_tabela != -1:
+        # Substitui a parte da tabela existente com a nova
+        conteudo = conteudo[:inicio_tabela] + [tabela] + conteudo[inicio_tabela + 1:]
+    else:
+        # Se não encontrar uma seção, adiciona a seção e a tabela ao final
+        conteudo.append("\n## Exemplos Adicionados\n\n" + tabela)
+    
+    # Salva o conteúdo atualizado de volta no README
+    with open(README_FILE, "w", encoding='utf-8') as readme:
+        readme.writelines(conteudo)
+    
+    print("Tabela atualizada com sucesso no README.md!")
+
+if __name__ == "__main__":
+    atualizar_tabela()


### PR DESCRIPTION
Criei um script em Python que, ao ser executado, automaticamente atualiza a tabela de exemplos no arquivo README.md. O script percorre a pasta code-atividades, identifica todos os arquivos Python (.py) presentes, e gera uma tabela com os nomes desses arquivos e links para acessá-los diretamente. Caso a tabela já exista no arquivo README.md, ela é atualizada com as informações mais recentes, garantindo que a documentação reflita todos os códigos adicionados à pasta. Se a tabela não estiver presente, o script cria a seção "Exemplos Adicionados" e insere a tabela ao final do arquivo. Esse processo ajuda a manter a documentação sempre atualizada de forma automática, sem a necessidade de intervenção manual.